### PR TITLE
scope-and-visibility.md: dot/index notation

### DIFF
--- a/content/overview/scope-and-visibility.md
+++ b/content/overview/scope-and-visibility.md
@@ -9,8 +9,8 @@ weight: 20
 Cue will reference a value from the nearest enclosing scope.
 Some quirks are:
 
-- fields without quotes you can reference as identifiers
-- fields with quotes require dot notation
+- fields without quotes you can reference as identifiers and with dot notation
+- fields with quotes require index notation
 - fields defined across scopes require sufficient paths to resolve
 
 {{< chromaHTML file="code/overview/scope-and-visibility/lookup.html" title="lookup.cue" >}}


### PR DESCRIPTION
I'm confused by this -- `A["user-id"]` is a quoted field name, so it _can't_ use dot notation, right? I would usually call `[]` the index operator.