### PR TITLE
Update expressions.md

### DIFF
--- a/content/overview/expressions.md
+++ b/content/overview/expressions.md
@@ -60,7 +60,7 @@ Cue supports regular expression constraints with the `=~` and `!~` operators.
 >}}
 
 They are based on [Go's regular expressions](https://golang.org/pkg/regexp/).
-Cue also has some additional {{<cuedoc page="/pkg/regexp" >}}regexp helpers{{</cuedoc>}}.:w
+Cue also has some additional {{<cuedoc page="/pkg/regexp" >}}regexp helpers{{</cuedoc>}}.
 
 
 


### PR DESCRIPTION
Removes a stray `:w`. Presumably a not-quite-out-of-insert-mode-yet typo.