### PR TITLE
Fix code example

### DIFF
--- a/code/first-steps/generate-configuration/conjunction.cue
+++ b/code/first-steps/generate-configuration/conjunction.cue
@@ -31,7 +31,9 @@
 
 // Additionally apply our labels buildup to the resources
 #Schema: {
-	metadata: #metadata & #myLabels
+	metadata: #metadata & {
+		labels: #myLabels
+	}
 }
 
 #Deployment: {


### PR DESCRIPTION
The error was `_|_ // #Schema.metadata.labels: conflicting values string and {[string]:string} (mismatched types string and struct)`