### PR TITLE
fix subsume.txt

### DIFF
--- a/code/go-api/basics/Makefile
+++ b/code/go-api/basics/Makefile
@@ -1,6 +1,7 @@
 tests = context \
 				errors \
-				printing
+				printing \
+				evaluating
 
 verifies = $(addprefix verify_, $(tests))
 

--- a/code/go-api/basics/evaluating/Makefile
+++ b/code/go-api/basics/evaluating/Makefile
@@ -1,6 +1,6 @@
 DIFF_CMD   = @git diff --exit-code
 
-tests = eval
+tests = eval subsume unify validate
 
 .PHONY: all
 all: $(tests)
@@ -8,4 +8,16 @@ all: $(tests)
 eval: eval.go
 	@go run eval.go > eval.txt
 	$(DIFF_CMD) eval.txt
+
+subsume: subsume.go
+	@go run subsume.go > subsume.txt
+	$(DIFF_CMD) subsume.txt
+
+unify: unify.go
+	@go run unify.go > unify.txt
+	$(DIFF_CMD) unify.txt
+
+validate: validate.go
+	@go run validate.go > validate.txt
+	$(DIFF_CMD) validate.txt
 

--- a/code/go-api/basics/evaluating/subsume.go
+++ b/code/go-api/basics/evaluating/subsume.go
@@ -8,16 +8,23 @@ import (
 	"cuelang.org/go/cue/errors"
 )
 
-const schema = `
+const schemaWithNumber =`
 {
 	i: number
 	s: string
 }
 `
 
+const schemaWithInt = `
+{
+	i: int
+	s: string
+}
+`
+
 const constraint = `
 {
-	i: >10
+	i: >10 // this will only be subsumed by number, not int
 	s: =~"^foo"
 }
 `
@@ -29,7 +36,7 @@ const val = `
 }
 `
 
-const bad = `
+const constraintType = `
 {
 	i: uint
 	s: string
@@ -37,20 +44,29 @@ const bad = `
 `
 
 func main() {
-	c := cuecontext.New()
-	s := c.CompileString(schema, cue.Filename("schema.cue"))
-	r := c.CompileString(constraint, cue.Filename("constrain.cue"))
-	v := c.CompileString(val, cue.Filename("val.cue"))
-	b := c.CompileString(bad, cue.Filename("bad.cue"))
+	ctx := cuecontext.New()
+	sn := ctx.CompileString(schemaWithNumber, cue.Filename("schema_number.cue"))
+	si := ctx.CompileString(schemaWithInt, cue.Filename("schema_int.cue"))
+	c := ctx.CompileString(constraint, cue.Filename("constraint.cue"))
+	v := ctx.CompileString(val, cue.Filename("val.cue"))
+	b := ctx.CompileString(constraintType, cue.Filename("bad.cue"))
 
 	// check subsumptions
-	printErr("s > r", s.Subsume(r))
-	printErr("r > s", r.Subsume(s))
+	printErr("sn > c", sn.Subsume(c))
+	printErr("c > sn", c.Subsume(sn))
 
-	printErr("s > v", s.Subsume(v))
-	printErr("v > s", v.Subsume(s))
+	printErr("sn > v", sn.Subsume(v))
+	printErr("v > sn", v.Subsume(sn))
 
-	printErr("s > b", s.Subsume(b))
+	// this seems not intuitive, we'll talk it later
+	printErr("si > c", si.Subsume(c))
+	printErr("c > si", c.Subsume(si))
+
+	printErr("si > v", si.Subsume(v))
+	printErr("v > si", v.Subsume(si))
+
+
+	printErr("s > b", si.Subsume(b))
 	printErr("b > v", b.Subsume(v))
 }
 

--- a/code/go-api/basics/evaluating/subsume.txt
+++ b/code/go-api/basics/evaluating/subsume.txt
@@ -1,10 +1,25 @@
-r > s:
+c > sn:
 field i not present in {i:number,s:string}:
-    schema.cue:2:1
+    schema_number.cue:2:1
 missing field "i"
 
-v > s:
+v > sn:
 field i not present in {i:number,s:string}:
-    schema.cue:2:1
+    schema_number.cue:2:1
+missing field "i"
+
+si > c:
+field i not present in {i:>10,s:=~"^foo"}:
+    constraint.cue:2:1
+missing field "i"
+
+c > si:
+field i not present in {i:int,s:string}:
+    schema_int.cue:2:1
+missing field "i"
+
+v > si:
+field i not present in {i:int,s:string}:
+    schema_int.cue:2:1
 missing field "i"
 

--- a/code/go-api/basics/evaluating/subsume.txt
+++ b/code/go-api/basics/evaluating/subsume.txt
@@ -1,8 +1,3 @@
-s > r:
-field i not present in {i:>10,s:=~"^foo"}:
-    constrain.cue:2:1
-missing field "i"
-
 r > s:
 field i not present in {i:int,s:string}:
     schema.cue:2:1

--- a/code/go-api/basics/evaluating/subsume.txt
+++ b/code/go-api/basics/evaluating/subsume.txt
@@ -1,10 +1,10 @@
 r > s:
-field i not present in {i:int,s:string}:
+field i not present in {i:number,s:string}:
     schema.cue:2:1
 missing field "i"
 
 v > s:
-field i not present in {i:int,s:string}:
+field i not present in {i:number,s:string}:
     schema.cue:2:1
 missing field "i"
 

--- a/content/go-api/basics/evaluating.md
+++ b/content/go-api/basics/evaluating.md
@@ -58,6 +58,9 @@ Subsumption is a powerful technique which compares the relation of two values wi
 `Subsume` will tell you if one value is an instance of another,
 or to say it another way, if one value is backwards compatible with another.
 
+In the following example, we check subsume in both directions. 
+For each pair, we expect one to pass and one to fail.
+
 {{< codePane2
 	file1="code/go-api/basics/evaluating/subsume.go"  lang1="go"  title1="subsume.go"
 	file2="code/go-api/basics/evaluating/subsume.txt" lang2="txt" title2="go run subsume.go"
@@ -65,7 +68,8 @@ or to say it another way, if one value is backwards compatible with another.
 
 [Subsume Docs](https://pkg.go.dev/cuelang.org/go@v0.4.0/cue#Value.Subsume)
 
-__see [issue 1330](https://github.com/cue-lang/cue/discussions/1330) for a discussion on the output which seems to have inconsistencies__
+__Why `>10` won't be subsumed by `int`? See [issue 1330](https://github.com/cue-lang/cue/discussions/1330) for a discussion on the output which seems to have inconsistencies__
+
 
 ### Value.Eval()
 


### PR DESCRIPTION
I run the example and the result seems not right. And
```cue
{
	i: >10
	s: =~"^foo"
}
```
is an instance of
```cue
{
	i: number
	s: string
}
```

Can you confirm this result?