### PR TITLE
feat: update CSP header

### DIFF
--- a/ci/server.conf
+++ b/ci/server.conf
@@ -5,7 +5,16 @@ server {
   add_header X-Frame-Options SAMEORIGIN;
   add_header X-Content-Type-Options nosniff;
   add_header Referrer-Policy no-referrer-when-downgrade;
-  add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: www.googletagmanager.com www.google-analytics.com; connect-src 'self' www.google-analytics.com; form-action 'self' https://hofstadter.us5.list-manage.com; frame-src youtube.com www.youtube.com;";
+
+  set $CSP_DEFAULT_SRC "default-src 'self'";
+  set $CSP_SCRIPT_SRC "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com";
+  set $CSP_STYLE_SRC "style-src 'self' 'unsafe-inline'";
+  set $CSP_IMG_SRC "img-src 'self' avatars.githubusercontent.com data: www.googletagmanager.com www.google-analytics.com";
+  set $CSP_CONNECT_SRC "connect-src 'self' www.google-analytics.com";
+  set $CSP_FORM_ACTION "form-action 'self' https://hofstadter.us5.list-manage.com";
+  set $CSP_FRAME_SRC "frame-src youtube.com www.youtube.com";
+
+  add_header Content-Security-Policy "${CSP_DEFAULT_SRC}; ${CSP_SCRIPT_SRC}; ${CSP_STYLE_SRC}; ${CSP_IMG_SRC}; ${CSP_CONNECT_SRC}; ${CSP_FORM_ACTION}; ${CSP_FRAME_SRC};";
 
   root /usr/share/nginx/html/;
   index index.html;


### PR DESCRIPTION
I didn't notice the CSP header. 

I update the `img-src` and add `avatars.githubusercontent.com`.

And I add a few nginx variables because the header too long to maintain.

![image](https://user-images.githubusercontent.com/12080364/152124022-bf880bd3-e477-4bc1-8ddf-2307bc567735.png)
