### PR TITLE
Make Foundations Definitions example easier to manipulate

### DIFF
--- a/code/overview/foundations/definition.cue
+++ b/code/overview/foundations/definition.cue
@@ -3,7 +3,7 @@
 	title:  string
 	year:   int
 
-	// ...  uncomment to open, must be last
+	// ...  // 2. uncomment to open and fix error, must be last
 }
 
 // This is a conjunction, it says "album" has to be "#Album"
@@ -12,5 +12,5 @@ album: #Album & {
 	title:  "Led Zeppelin I"
 	year:   1969
 
-	// studio: true  (uncomment to trigger error)
+	// studio: true  // 1. uncomment to trigger error
 }


### PR DESCRIPTION
When I went through the example, once I uncommented the lines I got errors from `cue`. The cause is pretty obvious -- the tutorial comments are not themselves commented -- but added friction in trying to learn what the tutorial was trying to convey.

I've added a second comment marker to ensure the tutorial comments remain commented even when the lines are uncommented to follow the Cuetorial.

I also realised that, to best demonstrate the effect, the second comment needed to be uncommented first. So I've added numbers to guide learners on what order to do things for best comprehension.